### PR TITLE
coreidle: deprecate FPGA_MSG macro

### DIFF
--- a/tools/coreidle/coreidle.c
+++ b/tools/coreidle/coreidle.c
@@ -1,4 +1,4 @@
-// Copyright(c) 2017-2020, Intel Corporation
+// Copyright(c) 2017-2021, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -77,24 +77,24 @@ fpga_result sysfs_read_u64(const char *path, uint64_t *u)
 
 	fd = open(path, O_RDONLY);
 	if (fd < 0) {
-		FPGA_MSG("open(%s) failed", path);
+		OPAE_MSG("open(%s) failed", path);
 		return FPGA_NOT_FOUND;
 	}
 
 	if ((off_t) -1 == lseek(fd, 0, SEEK_SET)) {
-		FPGA_MSG("seek failed");
+		OPAE_MSG("seek failed");
 		goto out_close;
 	}
 
 	do {
 		res = read(fd, buf + b, sizeof(buf) -b);
 		if (res <= 0) {
-			FPGA_MSG("Read from %s failed", path);
+			OPAE_MSG("Read from %s failed", path);
 			goto out_close;
 		}
 		b += res;
 		if (((unsigned) b > sizeof(buf)) || (b <= 0)) {
-			FPGA_MSG("Unexpected size reading from %s", path);
+			OPAE_MSG("Unexpected size reading from %s", path);
 			goto out_close;
 		}
 	} while (buf[b - 1] != '\n' && buf[b - 1] != '\0' && (unsigned) b < sizeof(buf));


### PR DESCRIPTION
Use OPAE_MSG instead.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>