### PR TITLE
fpgad: parent fix and ref count update

### DIFF
--- a/tools/fpgad/monitored_device.c
+++ b/tools/fpgad/monitored_device.c
@@ -192,31 +192,28 @@ STATIC bool mon_consider_device(struct fpgad_config *c, fpga_token token)
 		// The parent token's guid is the PR interface ID.
 
 		res = fpgaPropertiesGetParent(props, &parent);
-		if (res != FPGA_OK) {
-			LOG("failed to get parent token\n");
-			goto err_out_destroy;
-		}
+		if (res == FPGA_OK) {
 
-		res = fpgaGetProperties(parent, &parent_props);
-		if (res != FPGA_OK) {
-			LOG("failed to get parent properties\n");
-			goto err_out_destroy;
-		}
-
-		res = fpgaPropertiesGetGUID(parent_props, &pr_ifc_id);
-		if (res != FPGA_OK) {
-			LOG("failed to get PR interface ID\n");
-			goto err_out_destroy;
-		}
-
-		fpgaDestroyProperties(&parent_props);
-		fpgaDestroyToken(&parent);
-
-		for (i = 0 ; i < c->num_null_gbs ; ++i) {
-			if (!uuid_compare(c->null_gbs[i].pr_interface_id,
-					  pr_ifc_id)) {
-				bitstr = &c->null_gbs[i];
-				break;
+			res = fpgaGetProperties(parent, &parent_props);
+			if (res != FPGA_OK) {
+				LOG("failed to get parent properties\n");
+				goto err_out_destroy;
+			}
+	
+			res = fpgaPropertiesGetGUID(parent_props, &pr_ifc_id);
+			if (res != FPGA_OK) {
+				LOG("failed to get PR interface ID\n");
+				goto err_out_destroy;
+			}
+	
+			fpgaDestroyProperties(&parent_props);
+	
+			for (i = 0 ; i < c->num_null_gbs ; ++i) {
+				if (!uuid_compare(c->null_gbs[i].pr_interface_id,
+						  pr_ifc_id)) {
+					bitstr = &c->null_gbs[i];
+					break;
+				}
 			}
 		}
 	}
@@ -340,8 +337,6 @@ STATIC bool mon_consider_device(struct fpgad_config *c, fpga_token token)
 err_out_destroy:
 	if (props)
 		fpgaDestroyProperties(&props);
-	if (parent)
-		fpgaDestroyToken(&parent);
 	if (parent_props)
 		fpgaDestroyProperties(&parent_props);
 	return false;

--- a/tools/fpgad/monitored_device.c
+++ b/tools/fpgad/monitored_device.c
@@ -199,15 +199,15 @@ STATIC bool mon_consider_device(struct fpgad_config *c, fpga_token token)
 				LOG("failed to get parent properties\n");
 				goto err_out_destroy;
 			}
-	
+
 			res = fpgaPropertiesGetGUID(parent_props, &pr_ifc_id);
 			if (res != FPGA_OK) {
 				LOG("failed to get PR interface ID\n");
 				goto err_out_destroy;
 			}
-	
+
 			fpgaDestroyProperties(&parent_props);
-	
+
 			for (i = 0 ; i < c->num_null_gbs ; ++i) {
 				if (!uuid_compare(c->null_gbs[i].pr_interface_id,
 						  pr_ifc_id)) {

--- a/tools/fpgad/plugins/fpgad-xfpga/fpgad-xfpga.c
+++ b/tools/fpgad/plugins/fpgad-xfpga/fpgad-xfpga.c
@@ -412,7 +412,7 @@ void fpgad_xfpga_respond_AP6_and_Null_GBS(fpgad_monitored_device *d,
 		if (res != FPGA_OK) {
 			LOG("(AP6) failed to get FME handle! : %s\n",
 			    fpgaErrStr(res));
-			goto out_destroy_fme_tok;
+			goto out_destroy_props;
 		}
 
 		LOG("programming \"%s\": ", d->bitstr->filename);
@@ -428,8 +428,7 @@ void fpgad_xfpga_respond_AP6_and_Null_GBS(fpgad_monitored_device *d,
 			LOG("FAILED : %s\n", fpgaErrStr(res));
 
 		fpgaClose(fme_h);
-out_destroy_fme_tok:
-		fpgaDestroyToken(&fme_tok);
+
 out_destroy_props:
 		fpgaDestroyProperties(&prop);
 	} else


### PR DESCRIPTION
Fix mon_consider_device() so that it doesn't abort when there
is no parent token found. This allows monitoring the
FPGA_ACCELERATOR when the FPGA_DEVICE is not bound to a driver.

With the addition of ref counting for tokens, one should not
call fpgaDestroyToken() on a parent token gotten by
fpgaPropertiesGetParent().

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>