### PR TITLE
build: remove fpgaperf_counter

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -27,4 +27,4 @@
 opae_add_subdirectory(coreidle)
 opae_add_subdirectory(fpgad)
 opae_add_subdirectory(hssi)
-opae_add_subdirectory(fpgaperf_counter)
+#opae_add_subdirectory(fpgaperf_counter)


### PR DESCRIPTION
To avoid conflict with current opae-sdk:master.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>