### PR TITLE
cmake: build C/C++ deps from source when not found

### DIFF
--- a/samples/hello_mpf_afu/sw/CMakeLists.txt
+++ b/samples/hello_mpf_afu/sw/CMakeLists.txt
@@ -1,4 +1,4 @@
-## Copyright(c) 2014-2018, Intel Corporation
+## Copyright(c) 2014-2023, Intel Corporation
 ##
 ## Redistribution  and  use  in source  and  binary  forms,  with  or  without
 ## modification, are permitted provided that the following conditions are met:
@@ -38,9 +38,9 @@ add_executable(hello_mpf_afu
   ${OPAE_SDK_SOURCE}/samples/base/sw/opae_svc_wrapper.cpp
   hello_mpf_afu.cpp)
 if(BUILD_LIBOPAE_C)
-  target_link_libraries(hello_mpf_afu ${libjson-c_LIBRARIES} uuid MPF ${CMAKE_THREAD_LIBS_INIT} opae-c)
+  target_link_libraries(hello_mpf_afu ${json-c_LIBRARIES} uuid MPF ${CMAKE_THREAD_LIBS_INIT} opae-c)
 else()
-  target_link_libraries(hello_mpf_afu ${libjson-c_LIBRARIES} uuid MPF ${CMAKE_THREAD_LIBS_INIT} opae-c-ase)
+  target_link_libraries(hello_mpf_afu ${json-c_LIBRARIES} uuid MPF ${CMAKE_THREAD_LIBS_INIT} opae-c-ase)
 endif()
 
 install(FILES hello_mpf_afu.cpp

--- a/tests/coreidle/CMakeLists.txt
+++ b/tests/coreidle/CMakeLists.txt
@@ -1,4 +1,4 @@
-## Copyright(c) 2020, Intel Corporation
+## Copyright(c) 2020-2023, Intel Corporation
 ##
 ## Redistribution  and  use  in source  and  binary  forms,  with  or  without
 ## modification, are permitted provided that the following conditions are met:
@@ -45,5 +45,5 @@ opae_test_add(TARGET test_coreidle_main_c
     LIBS
         coreidle-static
         bitstream
-        ${libjson-c_LIBRARIES}
+        ${json-c_LIBRARIES}
 )

--- a/tests/fpgaperf/CMakeLists.txt
+++ b/tests/fpgaperf/CMakeLists.txt
@@ -1,4 +1,4 @@
-## Copyright(c) 2021-2022, Intel Corporation
+## Copyright(c) 2021-2023, Intel Corporation
 ##
 ## Redistribution  and  use  in source  and  binary  forms,  with  or  without
 ## modification, are permitted provided that the following conditions are met:
@@ -23,6 +23,8 @@
 ## CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
 ## ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 ## POSSIBILITY OF SUCH DAMAGE.
+
+find_package(Udev)
 
 opae_test_add_static_lib(TARGET fpgaperf-static
     SOURCE ${OPAE_LEGACY_SOURCE}/tools/fpgaperf_counter/fpgaperf_counter.c

--- a/tools/coreidle/CMakeLists.txt
+++ b/tools/coreidle/CMakeLists.txt
@@ -1,4 +1,4 @@
-## Copyright(c) 2017-2020, Intel Corporation
+## Copyright(c) 2017-2023, Intel Corporation
 ##
 ## Redistribution  and  use  in source  and  binary  forms,  with  or  without
 ## modification, are permitted provided that the following conditions are met:
@@ -32,7 +32,7 @@ opae_add_executable(TARGET coreidle
         m
         bitstream
         opae-c
-        ${libjson-c_LIBRARIES}
-        ${libuuid_LIBRARIES}
+        ${json-c_LIBRARIES}
+        ${uuid_LIBRARIES}
     COMPONENT toolcoreidle
 )

--- a/tools/fpgaperf_counter/CMakeLists.txt
+++ b/tools/fpgaperf_counter/CMakeLists.txt
@@ -1,4 +1,4 @@
-## Copyright(c) 2021-2022, Intel Corporation
+## Copyright(c) 2021-2023, Intel Corporation
 ##
 ## Redistribution  and  use  in source  and  binary  forms,  with  or  without
 ## modification, are permitted provided that the following conditions are met:
@@ -23,6 +23,8 @@
 ## CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
 ## ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 ## POSSIBILITY OF SUCH DAMAGE.
+
+find_package(Udev)
 
 opae_add_shared_library(TARGET fpgaperf_counter
     SOURCE fpgaperf_counter.c


### PR DESCRIPTION
Updates to accompany https://github.com/OFS/opae-sdk/pull/2807

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>